### PR TITLE
Use parent supervisord.conf

### DIFF
--- a/gc2/Dockerfile
+++ b/gc2/Dockerfile
@@ -86,4 +86,4 @@ VOLUME  ["/var/www/geocloud2", "/var/log"]
 
 # Add Supervisor config and run the deamon
 ADD conf/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]


### PR DESCRIPTION
The parent supervisord.conf includes a line to include the `conf.d/*` files as well as has support for `supervisorctl` which is helpful when debugging. I feel it makes sense to use it when starting the server.
